### PR TITLE
fix: port와 db 연결 방식 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,11 +64,14 @@ jobs:
           # Docker Hub에 푸시한 이미지를 지정
           image: '${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/memo-app-repo/backend-deep-dive:${{ env.IMAGE_TAG }}'
 
+          # 9. [핵심] Cloud Run과 GCP SQL을 '내부 터널'로 연결
+          add-cloudsql-instances: ${{ secrets.GCP_SQL_CONNECTION_NAME }}
+
           min_instances: 1
 
           # Cloud Run 컨테이너에 환경 변수 주입
           env_vars: |
-            DB_URL=${{ secrets.DB_URL }}
+            DB_URL=jdbc:mysql://google/mydb?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${{ secrets.GCP_SQL_CONNECTION_NAME }}&useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
             DB_USERNAME=${{ secrets.DB_USERNAME }}
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.h2database:h2'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
-	implementation 'com.google.cloud.sql:mysql-socket-factory-connector-j-8'
+	implementation 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.14.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'com.h2database:h2'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
-	implementation 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.14.0'
+	implementation 'com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.25.3'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'com.h2database:h2'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
+	implementation 'com.google.cloud.sql:mysql-socket-factory-connector-j-8'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=openMission
 spring.profiles.include=oauth
-server.port=9090
+server.port=${PORT:9090}
 
 spring.datasource.url=${DB_URL:jdbc:h2:./mydb;AUTO_SERVER=TRUE}
 spring.datasource.username=${DB_USERNAME:sa}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Cloud SQL을 통한 내부 터널 기반 데이터베이스 연결 지원 추가로 보안 강화
  * 애플리케이션이 환경 변수(PORT)로 서버 포트를 읽어 기본값(9090)으로 동작 가능

* **변경 사항**
  * 배포 구성과 데이터베이스 연결 방식이 Cloud SQL 소켓 기반으로 업데이트되어 배포 시 해당 설정이 적용됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->