### PR TITLE
fix: java 버전 21을 사용하도록 통일

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           arguments: clean build
           cache-disabled: true
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       # 테스트와 빌드를 실행
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           arguments: clean build
           cache-disabled: true
-          java-version: '21'
-          distribution: 'temurin'
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,17 @@ jobs:
       - name: Run chmod to make gradlew executable
         run: chmod +x ./gradlew
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Build with Gradle (and run tests)
         uses: gradle/gradle-build-action@v3
         with:
           arguments: clean build
           cache-disabled: true # 캐시 오류 방지
-          java-version: '21'
-          distribution: 'temurin'
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           arguments: clean build
           cache-disabled: true # 캐시 오류 방지
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.17_10-jre-noble
+FROM eclipse-temurin:21.0.9_10-jre-ubi9-minimal
 
 ARG JAR_FILE=build/libs/*.jar
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ version = '0.0.1-SNAPSHOT'
 description = 'openMission'
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 configurations {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 애플리케이션 실행 환경의 Java 런타임이 버전 17에서 21로 업그레이드되었습니다(로컬 빌드, CI/CD 파이프라인 및 배포용 컨테이너 이미지 포함).
  * 최신 Java 기능 및 보안 패치가 적용되며, 최소 요구 런타임이 Java 21 이상으로 변경되어 환경 설정과 배포 구성이 갱신되어야 합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->