### PR TITLE
fix: Cloud Run 배포 시 무한 리디렉션 문제 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,7 +76,7 @@ jobs:
           env_vars: |
             SPRING_PROFILES_ACTIVE=prod
             
-            DB_URL=jdbc:mysql://google/mydb?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${{ secrets.GCP_SQL_CONNECTION_NAME }}&useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+            DB_URL=jdbc:mysql:///mydb?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${{ secrets.GCP_SQL_CONNECTION_NAME }}&useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
             DB_USERNAME=${{ secrets.DB_USERNAME }}
             DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}

--- a/src/main/java/com/precourse/openMission/config/auth/SecurityConfig.java
+++ b/src/main/java/com/precourse/openMission/config/auth/SecurityConfig.java
@@ -19,28 +19,8 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
-    // (운영/배포) 환경 전용 SecurityFilterChain
     @Bean
-    @Profile("prod")
-    public SecurityFilterChain prodFilterChain(HttpSecurity http) throws Exception {
-        http.requiresChannel(channel -> channel
-                .anyRequest().requiresSecure()
-        );
-
-        commonSecurityConfig(http);
-
-        return http.build();
-    }
-
-    @Bean
-    @Profile("!prod")
-    public SecurityFilterChain devFilterChain(HttpSecurity http) throws Exception {
-        commonSecurityConfig(http);
-
-        return http.build();
-    }
-
-    private void commonSecurityConfig(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((authz) -> authz
                         .requestMatchers("/").permitAll()
@@ -66,6 +46,8 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService)
                         )
                 );
+
+        return http.build();
     }
 
     @Bean


### PR DESCRIPTION
- SecurityConfig에서 prod 프로필용 requiresSecure() 설정 제거
- Cloud Run의 TLS Termination으로 인한 HTTP/HTTPS 리디렉션 루프 방지
- HTTPS 처리는 Cloud Run 로드밸런서에 위임

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 보안 필터 설정을 통합하여 설정 복잡도를 감소시켰습니다.
  * 환경별 보안 정책 분기를 제거하고 단일 보안 체인으로 통합했습니다.

* **기타**
  * 데이터베이스 연결 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->